### PR TITLE
Fix for manifest merge failed when allowBackup is set in main project

### DIFF
--- a/lib/adn/androiddevicenames/src/main/AndroidManifest.xml
+++ b/lib/adn/androiddevicenames/src/main/AndroidManifest.xml
@@ -1,10 +1,5 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="tslamic.github.io.androiddevicenames">
+<manifest package="tslamic.github.io.androiddevicenames">
 
-    <application
-        android:allowBackup="true"
-        android:label="@string/app_name">
-
-    </application>
+    <application />
 
 </manifest>


### PR DESCRIPTION
Fix #4 

Libraries don't need anything special in AndroidManifest file
