### PR TITLE
Update/tweak generator script, update sqlite db to most recent (05/30)

### DIFF
--- a/generator/generator.py
+++ b/generator/generator.py
@@ -58,7 +58,7 @@ def _log(message):
 
 
 def _main():
-    gen = Generator(GooglePlayEngine(), CorcoranGithubEngine())
+    gen = Generator(CorcoranGithubEngine(), GooglePlayEngine())
     gen.create_database()
 
 
@@ -119,8 +119,8 @@ class CorcoranGithubEngine(Engine):
     """ Jeff Corcoran GitHub device list. """
 
     DELIMITER = ' = '
-    URL = "https://github.com/corcoran/AndroidDeviceNames/blob/master" \
-          "/generator/devices/cached.devices"
+    URL = "https://raw.githubusercontent.com/corcoran" \
+          "/android-device-names-registry/master/parsed.devices"
 
     def devices(self):
         tuple_list = []


### PR DESCRIPTION
I switched the generator to parse CorcoranGithubEngine first because it contains fixes for improperly labeled devices in the Google list.  I also pointed it at another repo that's dedicated to being a main repo for jdrummler updates as well as fixes from the XDA Developers community.

Finally, the SQLite DB is updated to the most recent as of today.  I'm using it in the latest version of [XDA Labs](https://www.xda-developers.com/xda-labs/) that I just pushed out to testers.